### PR TITLE
Allows Embedder content to be linkcable in TinyMCE.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 1.5b3 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Allows Embedder content to be linkcable in TinyMCE.
+  [idgserpro]
+
 - Add ``cssselect`` as pakage dependency.
   [idgserpro]
 

--- a/src/sc/embedder/adapters.py
+++ b/src/sc/embedder/adapters.py
@@ -3,6 +3,7 @@ from lxml import cssselect
 from lxml import etree
 from lxml import html
 from Products.TinyMCE.adapters.interfaces.JSONDetails import IJSONDetails
+from Products.TinyMCE.adapters.JSONDetails import JSONDetails
 from urllib2 import quote
 from zope.interface import implementer
 
@@ -10,21 +11,17 @@ import json
 
 
 @implementer(IJSONDetails)
-class JSONDetails(object):
+class JSONDetails(JSONDetails):
     """Return details of the current object in JSON"""
-
-    def __init__(self, context):
-        """Constructor"""
-        self.context = context
 
     def getDetails(self):
         """Builds a JSON object based on the details
            of this object.
         """
 
-        results = {}
-        results['title'] = self.context.title_or_id()
-        results['description'] = self.context.Description()
+        results = json.loads(super(JSONDetails, self).getDetails())
+
+        results['description'] = self.context.description
 
         tree = etree.HTML(self.context.embed_html)
         sel = cssselect.CSSSelector('body > *')
@@ -38,12 +35,4 @@ class JSONDetails(object):
         results['thumb_html'] = quote(html.tostring(el))
         results['embed_html'] = quote(self.context.embed_html)
 
-        results.update(self.additionalDetails())
-
         return json.dumps(results)
-
-    def additionalDetails(self):
-        """Hook to allow subclasses to supplement or
-           override the default set of results
-        """
-        return {}

--- a/src/sc/embedder/tests/test_adapters.py
+++ b/src/sc/embedder/tests/test_adapters.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""Module with the apapters tests."""
+
+from plone import api
+from sc.embedder.testing import INTEGRATION_TESTING
+from sc.embedder.testing import IS_PLONE_5
+
+import unittest
+
+
+class AdaptersTestCase(unittest.TestCase):
+    """Adapters test class."""
+
+    layer = INTEGRATION_TESTING
+
+    def setUp(self):
+        """Tests configuration."""
+        self.portal = self.layer['portal']
+        with api.env.adopt_roles(['Manager']):
+            self.multimedia = api.content.create(
+                self.portal,
+                'sc.embedder',
+                title='Multimedia',
+                description='New Multimedia',
+                embed_html='<iframe width="480" height="270" '
+                'src="https://www.teste.com/embed/tesste?feature=oembed" '
+                'allowfullscreen></iframe>',
+                width=300,
+                height=200,
+            )
+
+    @unittest.skipIf(IS_PLONE_5, 'Plone 5 has no Products.TinyMCE.')
+    def test_json_details(self):
+        """Test if JSONDetails adapter returns all keys."""
+        from Products.TinyMCE.adapters.interfaces.JSONDetails import IJSONDetails
+        adapter = IJSONDetails(self.multimedia, None)
+        uid = self.multimedia.UID()
+        expected = '{{"thumb_html": "%3Ciframe%20width%3D%22188%22%20height'\
+            '%3D%22141%22%20src%3D%22https%3A//www.teste.com/embed/tesste%3F'\
+            'feature%3Doembed%22%20allowfullscreen%3E%3C/iframe%3E",'\
+            ' "uid_relative_url": "resolveuid/{0}", "thumb": "", "uid_url": '\
+            '"http://nohost/plone/resolveuid/{0}", "url": '\
+            '"http://nohost/plone/multimedia", "description": '\
+            '"New Multimedia", "title": "Multimedia", "embed_html": '\
+            '"%3Ciframe%20width%3D%22480%22%20height'\
+            '%3D%22270%22%20src%3D%22https%3A//www.teste.com/embed/'\
+            'tesste%3Ffeature%3Doembed%22%20allowfullscreen%3E%3C/'\
+            'iframe%3E", "anchors": []}}'.format(uid)
+        result = adapter.getDetails()
+        self.assertEqual(expected, result)


### PR DESCRIPTION
Fix #83